### PR TITLE
feat: docker builder

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -11,7 +11,10 @@ on:
 
 jobs:
   argus_builder:
-    uses: chanzuckerberg/github-actions/.github/workflows/argus-docker-build.yaml@v2.6.0
+    permissions:
+      id-token: write
+      contents: read
+    uses: chanzuckerberg/github-actions/.github/workflows/argus-docker-build.yaml@heathj/docker-build-runson
     secrets: inherit
     with:
       env: rdev

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -15,8 +15,11 @@ jobs:
       id-token: write
       contents: read
     uses: chanzuckerberg/github-actions/.github/workflows/argus-docker-build.yaml@heathj/docker-build-runson
+    
     secrets: inherit
     with:
+      app_id: ${{secrets.CZI_GITHUB_HELPER_APP_ID}}
+      pk: ${{secrets.CZI_GITHUB_HELPER_PK}}
       env: rdev
       images: |
         [

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -15,9 +15,10 @@ jobs:
       id-token: write
       contents: read
     uses: chanzuckerberg/github-actions/.github/workflows/argus-docker-build.yaml@heathj/docker-build-runson
-    with:
+    secrets:
       app_id: ${{ secrets.CZI_GITHUB_HELPER_APP_ID }}
       pk: ${{ secrets.CZI_GITHUB_HELPER_PK }}
+    with:
       env: rdev
       images: |
         [

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -20,6 +20,7 @@ jobs:
       pk: ${{ secrets.CZI_GITHUB_HELPER_PK }}
     with:
       env: rdev
+      ecr_root_path: ./.infra/ecr
       images: |
         [
           {

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -19,7 +19,7 @@ jobs:
       app_id: ${{ secrets.CZI_GITHUB_HELPER_APP_ID }}
       pk: ${{ secrets.CZI_GITHUB_HELPER_PK }}
     with:
-      env: rdev
+      envs: rdev
       ecr_root_path: ./django-mwe/.infra/ecr
       images: |
         [

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -20,7 +20,7 @@ jobs:
       pk: ${{ secrets.CZI_GITHUB_HELPER_PK }}
     with:
       env: rdev
-      ecr_root_path: ./.infra/ecr
+      ecr_root_path: django-mwe/.infra/ecr
       images: |
         [
           {

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -20,7 +20,7 @@ jobs:
       pk: ${{ secrets.CZI_GITHUB_HELPER_PK }}
     with:
       env: rdev
-      ecr_root_path: django-mwe/.infra/ecr
+      ecr_root_path: ./django-mwe/.infra/ecr
       images: |
         [
           {

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -15,11 +15,9 @@ jobs:
       id-token: write
       contents: read
     uses: chanzuckerberg/github-actions/.github/workflows/argus-docker-build.yaml@heathj/docker-build-runson
-    
-    secrets: inherit
     with:
-      app_id: ${{secrets.CZI_GITHUB_HELPER_APP_ID}}
-      pk: ${{secrets.CZI_GITHUB_HELPER_PK}}
+      app_id: ${{ secrets.CZI_GITHUB_HELPER_APP_ID }}
+      pk: ${{ secrets.CZI_GITHUB_HELPER_PK }}
       env: rdev
       images: |
         [

--- a/.infra/ecr/lifecycle-policy.json
+++ b/.infra/ecr/lifecycle-policy.json
@@ -1,0 +1,16 @@
+{
+  "rules": [
+      {
+          "rulePriority": 1,
+          "description": "Keep at most 1000 images",
+          "selection": {
+              "tagStatus": "any",
+              "countType": "imageCountMoreThan",
+              "countNumber": 1000
+          },
+          "action": {
+              "type": "expire"
+          }
+      }
+  ]
+}

--- a/.infra/ecr/repository-policy.json
+++ b/.infra/ecr/repository-policy.json
@@ -1,0 +1,29 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "OrganizationReadOnlyAccess",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:BatchGetImage",
+        "ecr:DescribeImageScanFindings",
+        "ecr:DescribeImages",
+        "ecr:DescribeRepositories",
+        "ecr:GetAuthorizationToken",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:GetLifecyclePolicy",
+        "ecr:GetLifecyclePolicyPreview",
+        "ecr:GetRepositoryPolicy",
+        "ecr:ListImages",
+        "ecr:ListTagsForResource"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "aws:PrincipalOrgID": "o-56v5gp5fcu"
+        }
+      }
+    }
+  ]
+}

--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -1,9 +1,9 @@
 services:
   backend:
     image:
-      tag: sha-00000000
+      tag: sha-2b49731
     replicaCount: 1
   #frontend:
   #  image:
-  #    tag: sha-00000000
+  #    tag: sha-2b49731
   #  replicaCount: 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.11
+#
 ADD hello /
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.11
-#
+##
 ADD hello /
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.11
-########
+#########
 ADD hello /
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.11
-#########
+##########
 ADD hello /
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.11
-######
+#######
 ADD hello /
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.11
-####
+#####
 ADD hello /
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.11
-############
+#############
 ADD hello /
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.11
-##
+###
 ADD hello /
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.11
-##########
+###########
 ADD hello /
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.11
-###
+####
 ADD hello /
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.11
-#####
+######
 ADD hello /
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.11
-#######
+########
 ADD hello /
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.11
-###########
+############
 ADD hello /
 COPY requirements.txt .
 RUN pip install -r requirements.txt


### PR DESCRIPTION
## Summary

This PR tags the docker builder action that uses a branch of the real action. The branch has a few changes that make it usable by org outside of CZI. For now, we can continue to use this branch until the hackathon is over.

## Things we needed to do to get it working

* Add org and repo to gh action role trust relationship
* Set up docker builder action to not use self-hosted runners
* Set up docker builder action to use a local path for ECR settings (before it was using a private repo to grab settings from)
* Set up the team and permissions on the API
* Register the app to Argus
* Set up the secrets and ID token permissions to work with personal Github projects (orgs have different rules apparently about thread through secrets)